### PR TITLE
fix behavior of combo boxes for social causes

### DIFF
--- a/components/common/Combobox/Combobox.tsx
+++ b/components/common/Combobox/Combobox.tsx
@@ -6,7 +6,12 @@ import {twMerge} from 'tailwind-merge';
 import {ExclamationCircleIcon} from '@heroicons/react/24/solid';
 import useDebounce from 'hooks/useDebounce';
 import {ReactElement} from 'react';
-import {UseFormRegisterReturn} from 'react-hook-form';
+import {UseControllerReturn} from 'react-hook-form';
+
+export type ComboBoxSelectionType = {
+  id: string;
+  name: string;
+};
 
 export interface ComboboxProps
   extends React.DetailedHTMLProps<
@@ -15,7 +20,7 @@ export interface ComboboxProps
   > {
   label?: string | ReactElement;
   disabled?: boolean;
-  register?: UseFormRegisterReturn;
+  controller?: UseControllerReturn;
   errorMessage?: any;
   suffixContent?: any;
   prefixContent?: any;
@@ -35,7 +40,7 @@ export function Combobox({
   errorMessage,
   required,
   selected,
-  register,
+  controller,
   onSelected,
   onChangeInputSearch,
   ...props
@@ -44,6 +49,11 @@ export function Combobox({
   const [filteredItems, setFilteredItems] = useState<any[]>([]);
 
   const debouncedAmount = useDebounce(query, 500);
+
+  if (!name && controller?.field.name) name = controller.field.name;
+  if (controller) errorMessage = controller.fieldState.error?.message;
+  if (controller?.field.value && !controller.fieldState.isDirty)
+    selected = items.find((item) => item.id === controller.field.value) || '';
 
   useEffect(() => {
     onChangeInputSearch && onChangeInputSearch(debouncedAmount);
@@ -67,6 +77,7 @@ export function Combobox({
       value={selected}
       onChange={(item) => {
         onSelected && onSelected(item);
+        controller && controller.field.onChange(item.id);
       }}
       name={name}
       disabled={disabled}
@@ -89,12 +100,14 @@ export function Combobox({
           )}
           <div className="relative w-full cursor-default overflow-hidden rounded-lg bg-white text-left shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-teal-300 sm:text-sm">
             <UiCombobox.Input
+              name={`${name}-input`}
               className="w-full border-none py-2 pl-3 pr-10 text-sm leading-5 text-gray-900 outline-none focus:ring-0"
               displayValue={(item: any) => item?.name}
               onChange={(event) => setQuery(event.target.value)}
               // required={required}
               {...props}
-              {...register}
+              ref={controller?.field.ref}
+              onBlur={controller?.field.onBlur}
             />
 
             <UiCombobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">

--- a/components/common/Post/CausesTagBar/CausesTagBar.tsx
+++ b/components/common/Post/CausesTagBar/CausesTagBar.tsx
@@ -1,29 +1,16 @@
-import {UseFormRegisterReturn} from 'react-hook-form';
-import {useEffect, useMemo, useState} from 'react';
+import {UseControllerReturn} from 'react-hook-form';
+import {useMemo} from 'react';
 import {Avatar, Combobox} from '@components/common';
 import Data, {getText} from '@socious/data';
 
 const items = Object.keys(Data.SocialCauses);
 
-type selectionType = {
-  id: string;
-  name: string;
-};
-
 interface CausesTagBarProps {
   src: string;
-  register: UseFormRegisterReturn;
-  errorMessage?: any;
-  preSelected?: string;
+  controller: UseControllerReturn;
 }
 
-export const CausesTagBar = ({
-  src,
-  register,
-  errorMessage,
-  preSelected,
-}: CausesTagBarProps) => {
-  const [selected, setSelected] = useState<selectionType>();
+export const CausesTagBar = ({src, controller}: CausesTagBarProps) => {
   const localItems = useMemo(
     () => {
       const sorted = items.map((id) => ({
@@ -37,20 +24,13 @@ export const CausesTagBar = ({
       // todo: language
     ],
   );
-  useEffect(() => {
-    if (preSelected)
-      setSelected(localItems.find((item) => item.id === preSelected));
-  }, [localItems, preSelected]);
 
   return (
     <div className="-ml-6 -mr-6 flex items-center space-x-3 border-y-[0.5px] border-[#C3C8D9] p-4">
       <Avatar src={src} size="m" />
       <Combobox
-        register={register}
-        selected={selected}
-        onSelected={setSelected}
+        controller={controller}
         items={localItems}
-        errorMessage={errorMessage}
         required
         className="w-full"
         placeholder="social causes"

--- a/components/common/Post/Create/Step1/PostCreateStep1.tsx
+++ b/components/common/Post/Create/Step1/PostCreateStep1.tsx
@@ -1,7 +1,7 @@
 import React, {useRef} from 'react';
 import Modal from '@components/common/Modal/Modal';
 import {StepProps} from '@models/stepProps';
-import {useFormContext} from 'react-hook-form';
+import {useFormContext, useController, FieldValues} from 'react-hook-form';
 import TextArea from '@components/common/TextArea/TextArea';
 import Button from '@components/common/Button/Button';
 import useUser from 'hooks/useUser/useUser';
@@ -17,6 +17,9 @@ const PostCreateStep1 = ({onSubmit, setFile}: PostCreateStepProps) => {
   const {user} = useUser();
   const formMethods = useFormContext();
   const {handleSubmit, formState, register, getValues} = formMethods;
+  const causesTagsController = useController<FieldValues, string>({
+    name: 'causes_tags',
+  });
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
@@ -27,9 +30,7 @@ const PostCreateStep1 = ({onSubmit, setFile}: PostCreateStepProps) => {
         <div className="mt-2 space-y-8">
           <CausesTagBar
             src={user?.avatar?.url}
-            register={register('causes_tags')}
-            preSelected={getValues('causes_tags')}
-            errorMessage={formState?.errors?.['causes_tags']?.message}
+            controller={causesTagsController}
           />
           <TextArea
             placeholder="I feel like......"

--- a/components/common/Post/EditModal/EditModal.tsx
+++ b/components/common/Post/EditModal/EditModal.tsx
@@ -4,7 +4,7 @@ import {Avatar, Button, Modal, ModalProps, TextArea} from '@components/common';
 import {XMarkIcon} from '@heroicons/react/24/outline';
 import {joiResolver} from '@hookform/resolvers/joi';
 import {useUser} from '@hooks';
-import {useForm} from 'react-hook-form';
+import {FieldValues, useController, useForm} from 'react-hook-form';
 import useSWR from 'swr';
 import {get} from 'utils/request';
 import CausesTagBar from '../CausesTagBar/CausesTagBar';
@@ -42,13 +42,17 @@ const EditModal = ({
 
   const [file, setFile] = useState<any>(null);
 
-  const {handleSubmit, register, getValues, setValue, formState} = useForm({
+  const {handleSubmit, register, getValues, control, formState} = useForm({
     resolver: joiResolver(schemaEditPost),
     defaultValues: {
       content: post ? post.content : '',
-      causes_tags: post ? post.causes_tags : '',
+      causes_tags: post ? post.causes_tags[0] : '',
       link: post ? post.link || '' : '',
-    },
+    } as FieldValues,
+  });
+  const causesTagsController = useController<FieldValues, string>({
+    name: 'causes_tags',
+    control,
   });
 
   const onSubmit = useCallback(async () => {
@@ -101,9 +105,7 @@ const EditModal = ({
           <div className="mt-2">
             <CausesTagBar
               src={user?.avatar?.url}
-              preSelected={post && post.causes_tags?.[0]}
-              register={register('causes_tags')}
-              errorMessage={formState?.errors?.['causes_tags']?.message}
+              controller={causesTagsController}
             />
             <TextArea
               rows={post?.shared_id ? 6 : 10}

--- a/components/common/Post/ShareModal/ShareModalStep2/ShareModalStep2.tsx
+++ b/components/common/Post/ShareModal/ShareModalStep2/ShareModalStep2.tsx
@@ -1,7 +1,7 @@
 import {useRouter} from 'next/router';
 import {useCallback, useEffect, useState} from 'react';
 import {joiResolver} from '@hookform/resolvers/joi';
-import {useForm} from 'react-hook-form';
+import {FieldValues, useController, useForm} from 'react-hook-form';
 import useSWR from 'swr';
 
 import {Modal, TextArea, Button, Avatar} from 'components/common';
@@ -37,8 +37,15 @@ export const ShareModalStep2 = ({onShare}: shareModalStep2Props) => {
   const {user} = useUser();
   const [file, setFile] = useState<string>('');
 
-  const {register, handleSubmit, formState, getValues} = useForm({
+  const {register, handleSubmit, formState, control, getValues} = useForm({
     resolver: joiResolver(schemaSharePost),
+    defaultValues: {
+      causes_tags: post ? post.causes_tags[0] : '',
+    } as FieldValues,
+  });
+  const causesTagsController = useController<FieldValues, string>({
+    name: 'causes_tags',
+    control,
   });
 
   const onSubmit = useCallback(async () => {
@@ -73,8 +80,7 @@ export const ShareModalStep2 = ({onShare}: shareModalStep2Props) => {
         <div className="mt-2">
           <CausesTagBar
             src={user?.avatar?.url}
-            register={register('causes_tags')}
-            errorMessage={formState?.errors?.['causes_tags']?.message}
+            controller={causesTagsController}
           />
           <div className="-mr-6 -ml-6 flex items-center space-x-4 p-4">
             <Avatar src={user?.avatar?.url} size="m" />

--- a/pages/app/post/[pid].tsx
+++ b/pages/app/post/[pid].tsx
@@ -206,7 +206,7 @@ const Post = () => {
           {shareStep === 2 && <ShareModalStep2 onShare={onShare} />}
         </Modal>
 
-        {user.id === post.identity_id && (
+        {user?.id === post.identity_id && (
           <>
             {/* EDIT MODAL */}
             <EditModal


### PR DESCRIPTION
The headless combo box is controlled so it has to use a controller instead of `register`. It was working more or less by coincidence since it was ok to submit the input field's value, but in reality we have to submit the id, so this fixes creating/editing/share posts.

One more thing still bothering me is that the input triggers my password manager which things it's a login, but I couldn't fix that, and I have no idea what's causing it.