### PR TITLE
Fix FE auth issues (ENG-619)

### DIFF
--- a/layout/Navbar/Navbar.tsx
+++ b/layout/Navbar/Navbar.tsx
@@ -18,7 +18,9 @@ import {logout} from '@api/auth/actions';
 import Router from 'next/router';
 
 const Navbar = () => {
-  const {currentIdentity, identities, mutateIdentities, mutateUser} = useUser();
+  const {currentIdentity, identities, mutateIdentities, mutateUser} = useUser({
+    redirect: false,
+  });
 
   const onSwitchIdentity = async (identity: LoginIdentity) => {
     try {

--- a/layout/Navbar/Navbar.tsx
+++ b/layout/Navbar/Navbar.tsx
@@ -36,7 +36,7 @@ const Navbar = () => {
     const res = await logout();
     mutateIdentities();
     mutateUser();
-    if (res) Router.push('/');
+    if (res) Router.push('/app');
   };
 
   return (

--- a/pages/app/auth/login.tsx
+++ b/pages/app/auth/login.tsx
@@ -1,7 +1,7 @@
 import type {NextPage} from 'next';
 import {useRouter} from 'next/router';
 import Image from 'next/image';
-import {useState, useCallback, useContext} from 'react';
+import {useState, useCallback, useContext, useEffect} from 'react';
 import {useForm} from 'react-hook-form';
 import {joiResolver} from '@hookform/resolvers/joi';
 import Link from 'next/link';
@@ -22,13 +22,18 @@ const Login: NextPage = () => {
   const {redirect_to} = router.query;
   const [passwordShown, setPasswordShown] = useState<boolean>(false);
   const [showModal, setShowModal] = useState<boolean>(false);
-  const {mutateIdentities} = useUser({redirect: false});
+  const {identities, mutateIdentities} = useUser({redirect: false});
 
   const [errorMessage, setError] = useState<ErrorMessage>();
 
   const {register, handleSubmit, formState, getValues} = useForm({
     resolver: joiResolver(schemaLogin),
   });
+
+  useEffect(() => {
+    if (identities)
+      redirect_to ? router.push(redirect_to as string) : router.push('/app');
+  }, [identities, redirect_to, router]);
 
   const onSubmit = (data: any) => {
     handleLoginRequest();

--- a/pages/app/auth/login.tsx
+++ b/pages/app/auth/login.tsx
@@ -15,12 +15,14 @@ import {schemaLogin} from '@api/auth/validation';
 import logoCompony from 'asset/icons/logo-color.svg';
 import typoCompony from 'asset/icons/typo-company.svg';
 import {DefaultErrorMessage, ErrorMessage} from 'utils/request';
+import {useUser} from '@hooks';
 
 const Login: NextPage = () => {
   const router = useRouter();
   const {redirect_to} = router.query;
   const [passwordShown, setPasswordShown] = useState<boolean>(false);
   const [showModal, setShowModal] = useState<boolean>(false);
+  const {mutateIdentities} = useUser({redirect: false});
 
   const [errorMessage, setError] = useState<ErrorMessage>();
 
@@ -40,6 +42,7 @@ const Login: NextPage = () => {
     const password = getValues('password');
     try {
       await login(email, password);
+      await mutateIdentities();
       redirect_to ? router.push(redirect_to as string) : router.push('/app');
     } catch (e) {
       const error = e as AxiosError<any>;


### PR DESCRIPTION
- [x]  When viewing login page while authenticated, redirect to / or previous page
    
    We have a `redirect_to` system already, which works and should be used when present. But if it’s missing, and you’re authenticated, by default redirect to home, just in case the user got to the login page in some way that lost the `redirect_to` parameter.
    
    Also, the code that *sets* the `redirect_to` is not enabled yet. That goes in the `useUser` hook and it should use the current location.
    
- [x]  In some circumstances (needs testing) user has to log in twice
- [x]  Start page is not being shown (goes directly to login)
- [x]  Some users can’t log in
  (this one was a BE issue, @jeyem fixed it)
- [x]  Not going to onboarding after login (when profile is incomplete)